### PR TITLE
athenareader initial checkin

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,48 @@
+# :shell: athenareader
+
+`athenareader` is a utility tool which query S3 data via Athena from command line. It output query result in CSV format.
+
+## Authentication Method
+
+To avoid exposing access keys(Access Key ID and Secret Access Key) in command line, `athenareader` use [AWS CLI Config For Authentication](https://github.com/uber/athenadriver#use-aws-cli-config-for-authentication) method. Please make sure your environment variable **`AWS_SDK_LOAD_CONFIG`** is set.
+
+## How to use `athenareader`
+
+```
+athenareader -h
+NAME
+	athenareader - read athena data from command line
+
+SYNOPSIS
+	./athenareader [-b output_bucket] [-d database_name] [-q query_string_or_file] [-r]
+
+DESCRIPTION
+  -b string
+    	Athena resultset output bucket (default "s3://query-results-bucket-henrywu/")
+  -d string
+    	The database you want to query (default "sampledb")
+  -q string
+    	The SQL query string or a file containing SQL string (default "select 1")
+  -r	Display rows only, don't show the first row as columninfo
+
+EXAMPLES
+
+	$ athenareader -d sampledb -q "select request_timestamp,elb_name from elb_logs limit 2"
+	request_timestamp,elb_name
+	2015-01-03T00:00:00.516940Z,elb_demo_004
+	2015-01-03T00:00:00.902953Z,elb_demo_004
+
+	$ athenareader -d sampledb -q "select request_timestamp,elb_name from elb_logs limit 2" -r
+	2015-01-05T20:00:01.206255Z,elb_demo_002
+	2015-01-05T20:00:01.612598Z,elb_demo_008
+
+	$ athenareader -d sampledb -q tools/query.sql
+	request_timestamp,elb_name
+	2015-01-06T00:00:00.516940Z,elb_demo_009
+
+AUTHOR
+	Henry Fuheng Wu(henry.wu@uber.com)
+
+REPORTING BUGS
+	https://github.com/uber/athenadriver
+```

--- a/tools/athenareader.go
+++ b/tools/athenareader.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"database/sql"
+	"flag"
+	secret "github.com/uber/athenadriver/examples/constants"
+	drv "github.com/uber/athenadriver/go"
+	"io/ioutil"
+	"log"
+	"fmt"
+	"os"
+)
+
+var CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+// main will query Athena and print all columns and rows information in csv format
+func main() {
+	var bucket = flag.String("b", secret.OutputBucket, "Athena resultset output bucket")
+	var database = flag.String("d", "sampledb", "The database you want to query")
+	var query = flag.String("q", "select 1", "The SQL query string or a file containing SQL string")
+	var rowOnly = flag.Bool("r", false, "Display rows only, don't show the first row as columninfo")
+
+	flag.Usage = func() {
+		pre_body:="NAME\n\tathenareader - read athena data from command line\n\n"
+		desc := "\nEXAMPLES\n\n" +
+			"\t$ athenareader -d sampledb -q \"select request_timestamp,elb_name from elb_logs limit 2\"\n"+
+			"\trequest_timestamp,elb_name\n" +
+			"\t2015-01-03T00:00:00.516940Z,elb_demo_004\n" +
+			"\t2015-01-03T00:00:00.902953Z,elb_demo_004\n\n" +
+			"\t$ athenareader -d sampledb -q \"select request_timestamp,elb_name from elb_logs limit 2\" -r\n" +
+			"\t2015-01-05T20:00:01.206255Z,elb_demo_002\n" +
+			"\t2015-01-05T20:00:01.612598Z,elb_demo_008\n\n" +
+			"\t$ athenareader -d sampledb -q tools/query.sql\n" +
+			"\trequest_timestamp,elb_name\n" +
+			"\t2015-01-06T00:00:00.516940Z,elb_demo_009\n\n" +
+			"AUTHOR\n\tHenry Fuheng Wu(henry.wu@uber.com)\n\n" +
+			"REPORTING BUGS\n\thttps://github.com/uber/athenadriver\n"
+		fmt.Fprintf(CommandLine.Output(), pre_body)
+		fmt.Fprintf(CommandLine.Output(),
+			"SYNOPSIS\n\t%s [-b output_bucket] [-d database_name] [-q query_string_or_query_file] [-r]\n\nDESCRIPTION\n", os.Args[0])
+		flag.PrintDefaults()
+		fmt.Fprintf(CommandLine.Output(), desc)
+	}
+
+	flag.Parse()
+	// 1. Set AWS Credential in Driver Config.
+	conf, err := drv.NewDefaultConfig(*bucket, secret.Region, secret.AccessID, secret.SecretAccessKey)
+	conf.SetDB(*database)
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+	// 2. Open Connection.
+	dsn := conf.Stringify()
+	db, _ := sql.Open(drv.DriverName, dsn)
+	// 3. Query and print results
+	sqlString := *query
+	if _, err := os.Stat(*query); err == nil {
+		b, err := ioutil.ReadFile(*query)
+		if err != nil {
+			fmt.Print(err)
+		}
+		sqlString = string(b) // convert content to a 'string'
+	}
+	rows, err := db.Query(sqlString)
+	if err != nil {
+		println(err.Error())
+		return
+	}
+	defer rows.Close()
+	if *rowOnly {
+		println(drv.RowsToCSV(rows))
+		return
+	}
+	println(drv.ColsRowsToCSV(rows))
+}

--- a/tools/athenareader.go
+++ b/tools/athenareader.go
@@ -23,11 +23,11 @@ package main
 import (
 	"database/sql"
 	"flag"
+	"fmt"
 	secret "github.com/uber/athenadriver/examples/constants"
 	drv "github.com/uber/athenadriver/go"
 	"io/ioutil"
 	"log"
-	"fmt"
 	"os"
 )
 
@@ -41,9 +41,9 @@ func main() {
 	var rowOnly = flag.Bool("r", false, "Display rows only, don't show the first row as columninfo")
 
 	flag.Usage = func() {
-		pre_body:="NAME\n\tathenareader - read athena data from command line\n\n"
+		pre_body := "NAME\n\tathenareader - read athena data from command line\n\n"
 		desc := "\nEXAMPLES\n\n" +
-			"\t$ athenareader -d sampledb -q \"select request_timestamp,elb_name from elb_logs limit 2\"\n"+
+			"\t$ athenareader -d sampledb -q \"select request_timestamp,elb_name from elb_logs limit 2\"\n" +
 			"\trequest_timestamp,elb_name\n" +
 			"\t2015-01-03T00:00:00.516940Z,elb_demo_004\n" +
 			"\t2015-01-03T00:00:00.902953Z,elb_demo_004\n\n" +

--- a/tools/query.sql
+++ b/tools/query.sql
@@ -1,0 +1,1 @@
+select request_timestamp,elb_name from elb_logs limit 1


### PR DESCRIPTION
# :shell: athenareader

`athenareader` is a utility tool which query S3 data via Athena from command line. It output query result in CSV format.

## Authentication Method

To avoid exposing access keys(Access Key ID and Secret Access Key) in command line, `athenareader` use [AWS CLI Config For Authentication](https://github.com/uber/athenadriver#use-aws-cli-config-for-authentication) method. Please make sure your environment variable **`AWS_SDK_LOAD_CONFIG`** is set.

## How to use `athenareader`

```
athenareader -h
NAME
	athenareader - read athena data from command line

SYNOPSIS
	./athenareader [-b output_bucket] [-d database_name] [-q query_string_or_file] [-r]

DESCRIPTION
  -b string
    	Athena resultset output bucket (default "s3://query-results-bucket-henrywu/")
  -d string
    	The database you want to query (default "sampledb")
  -q string
    	The SQL query string or a file containing SQL string (default "select 1")
  -r	Display rows only, don't show the first row as columninfo

EXAMPLES

	$ athenareader -d sampledb -q "select request_timestamp,elb_name from elb_logs limit 2"
	request_timestamp,elb_name
	2015-01-03T00:00:00.516940Z,elb_demo_004
	2015-01-03T00:00:00.902953Z,elb_demo_004

	$ athenareader -d sampledb -q "select request_timestamp,elb_name from elb_logs limit 2" -r
	2015-01-05T20:00:01.206255Z,elb_demo_002
	2015-01-05T20:00:01.612598Z,elb_demo_008

	$ athenareader -d sampledb -q tools/query.sql
	request_timestamp,elb_name
	2015-01-06T00:00:00.516940Z,elb_demo_009

AUTHOR
	Henry Fuheng Wu(henry.wu@uber.com)

REPORTING BUGS
	https://github.com/uber/athenadriver
```
