### PR TITLE
Add pseudo commands - get_query_id, get_query_id_status, stop_query_id

### DIFF
--- a/examples/pc_get_query_id.go
+++ b/examples/pc_get_query_id.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"database/sql"
+	"os"
+
+	secret "github.com/uber/athenadriver/examples/constants"
+	drv "github.com/uber/athenadriver/go"
+)
+
+func main() {
+	// 1. Set AWS Credential in Driver Config.
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	conf, err := drv.NewDefaultConfig(secret.OutputBucket, secret.Region, secret.AccessID, secret.SecretAccessKey)
+	conf.SetLogging(true)
+	if err != nil {
+		panic(err)
+		return
+	}
+
+	// 2. Open Connection.
+	dsn := conf.Stringify()
+	db, _ := sql.Open(drv.DriverName, dsn)
+
+	// 3. Query with pseudo command `pc:get_query_id`
+	var qid string
+	_ = db.QueryRow("pc:get_query_id select url from sampledb.elb_logs limit 2").Scan(&qid)
+	println("Query ID: ", qid)
+}
+
+/*
+Sample Output:
+Query ID: c89088ab-595d-4ee6-a9ce-73b55aeb8953
+*/

--- a/examples/pc_get_query_id_status.go
+++ b/examples/pc_get_query_id_status.go
@@ -22,13 +22,13 @@ func main() {
 	dsn := conf.Stringify()
 	db, _ := sql.Open(drv.DriverName, dsn)
 
-	// 3. Query with pseudo command `pc:getqid`
-	var qid string
-	_ = db.QueryRow("pc:getqid select url from sampledb.elb_logs limit 2").Scan(&qid)
-	println("Query ID: ", qid)
+	// 3. Query with pseudo command `pc:get_query_id`
+	var qidStatus string
+	_ = db.QueryRow("pc:get_query_id_status c89088ab-595d-4ee6-a9ce-73b55aeb8953").Scan(&qidStatus)
+	println("Query ID c89088ab-595d-4ee6-a9ce-73b55aeb8953's Status: ", qidStatus)
 }
 
 /*
 Sample Output:
-Query ID: c89088ab-595d-4ee6-a9ce-73b55aeb8953
+Query ID c89088ab-595d-4ee6-a9ce-73b55aeb8953's Status:  SUCCEEDED
 */

--- a/examples/pc_stop_query_id.go
+++ b/examples/pc_stop_query_id.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"database/sql"
+	"os"
+
+	secret "github.com/uber/athenadriver/examples/constants"
+	drv "github.com/uber/athenadriver/go"
+)
+
+func main() {
+	// 1. Set AWS Credential in Driver Config.
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	conf, err := drv.NewDefaultConfig(secret.OutputBucket, secret.Region, secret.AccessID, secret.SecretAccessKey)
+	conf.SetLogging(true)
+	if err != nil {
+		panic(err)
+		return
+	}
+
+	// 2. Open Connection.
+	dsn := conf.Stringify()
+	db, _ := sql.Open(drv.DriverName, dsn)
+
+	// 3. Query with pseudo command `pc:get_query_id`
+	var qidStatus string
+	_ = db.QueryRow("pc:stop_query_id c89088ab-595d-4ee6-a9ce-73b55aeb8953").Scan(&qidStatus)
+	println("Stop Query ID c89088ab-595d-4ee6-a9ce-73b55aeb8953 returns:", qidStatus)
+}
+
+/*
+Sample Output:
+Stop Query ID c89088ab-595d-4ee6-a9ce-73b55aeb8953 returns: OK
+*/

--- a/examples/pseudo_command.go
+++ b/examples/pseudo_command.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"database/sql"
+	"os"
+
+	secret "github.com/uber/athenadriver/examples/constants"
+	drv "github.com/uber/athenadriver/go"
+)
+
+func main() {
+	// 1. Set AWS Credential in Driver Config.
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	conf, err := drv.NewDefaultConfig(secret.OutputBucket, secret.Region, secret.AccessID, secret.SecretAccessKey)
+	conf.SetLogging(true)
+	if err != nil {
+		panic(err)
+		return
+	}
+
+	// 2. Open Connection.
+	dsn := conf.Stringify()
+	db, _ := sql.Open(drv.DriverName, dsn)
+
+	// 3. Query with pseudo command `pc:getqid`
+	var qid string
+	_ = db.QueryRow("pc:getqid select url from sampledb.elb_logs limit 2").Scan(&qid)
+	println("Query ID: ", qid)
+}
+
+/*
+Sample Output:
+Query ID: c89088ab-595d-4ee6-a9ce-73b55aeb8953
+*/

--- a/examples/qid.go
+++ b/examples/qid.go
@@ -45,7 +45,7 @@ func main() {
 
 	logger, _ := zap.NewProduction()
 	defer logger.Sync()
-	// 3. Query cancellation after 2 seconds
+	// 3. Query
 	ctx := context.WithValue(context.Background(), drv.LoggerKey, logger)
 	rows, err := db.QueryContext(ctx, `3e6d49a6-999c-46ef-8295-7a101c327f90`)
 	if err != nil {

--- a/go/connection.go
+++ b/go/connection.go
@@ -234,11 +234,11 @@ func (c *Connection) QueryContext(ctx context.Context, query string, namedArgs [
 	var pseudoCommand = ""
 	if strings.HasPrefix(query, "pc:") {
 		query = strings.Trim(query[3:], " ")
-		if pseudoCommand = PC_GetQID; strings.HasPrefix(query, pseudoCommand+" ") {
+		if pseudoCommand = PCGetQID; strings.HasPrefix(query, pseudoCommand+" ") {
 			query = strings.Trim(query[len(pseudoCommand):], " ")
-		} else if pseudoCommand = PC_GetQIDStatus; strings.HasPrefix(query, pseudoCommand+" ") {
+		} else if pseudoCommand = PCGetQIDStatus; strings.HasPrefix(query, pseudoCommand+" ") {
 			query = strings.Trim(query[len(pseudoCommand):], " ")
-		} else if pseudoCommand = PC_StopQID; strings.HasPrefix(query, pseudoCommand+" ") {
+		} else if pseudoCommand = PCStopQID; strings.HasPrefix(query, pseudoCommand+" ") {
 			query = strings.Trim(query[len(pseudoCommand):], " ")
 		} else {
 			return nil, fmt.Errorf("pseudo command " + query + "doesn't exist")
@@ -301,7 +301,7 @@ func (c *Connection) QueryContext(ctx context.Context, query string, namedArgs [
 
 	// case 1 - query directly using QID
 	if IsQID(query) {
-		if pseudoCommand == PC_GetQIDStatus {
+		if pseudoCommand == PCGetQIDStatus {
 			statusResp, err := c.athenaAPI.GetQueryExecutionWithContext(ctx, &athena.GetQueryExecutionInput{
 				QueryExecutionId: aws.String(query),
 			})
@@ -315,7 +315,7 @@ func (c *Connection) QueryContext(ctx context.Context, query string, namedArgs [
 			}
 			return c.getHeaderlessSingleRowResultPage(ctx, *statusResp.QueryExecution.Status.State)
 		}
-		if pseudoCommand == PC_StopQID {
+		if pseudoCommand == PCStopQID {
 			_, err := c.athenaAPI.StopQueryExecutionWithContext(context.Background(), &athena.StopQueryExecutionInput{
 				QueryExecutionId: aws.String(query),
 			})
@@ -344,7 +344,7 @@ func (c *Connection) QueryContext(ctx context.Context, query string, namedArgs [
 		WorkGroup: aws.String(wg.Name),
 	})
 	if err != nil {
-		if pseudoCommand == PC_GetQID {
+		if pseudoCommand == PCGetQID {
 			if reqerr, ok := err.(awserr.RequestFailure); ok {
 				return c.getHeaderlessSingleRowResultPage(ctx, reqerr.RequestID())
 			}
@@ -357,7 +357,7 @@ func (c *Connection) QueryContext(ctx context.Context, query string, namedArgs [
 	obs.Scope().Timer(DriverName + ".query.startqueryexecution").Record(timeStartQueryExecution)
 
 	queryID := *resp.QueryExecutionId
-	if pseudoCommand == PC_GetQID {
+	if pseudoCommand == PCGetQID {
 		return c.getHeaderlessSingleRowResultPage(ctx, queryID)
 	}
 WAITING_FOR_RESULT:

--- a/go/connection.go
+++ b/go/connection.go
@@ -237,6 +237,8 @@ func (c *Connection) QueryContext(ctx context.Context, query string, namedArgs [
 		query = strings.Trim(query[3:], " ")
 		if strings.HasPrefix(query, "getqid") {
 			query = strings.Trim(query[6:], " ")
+		} else {
+			return nil, fmt.Errorf("pseudo command " + query + "doesn't exist")
 		}
 	}
 	query = GetTidySQL(query)

--- a/go/connection.go
+++ b/go/connection.go
@@ -236,7 +236,7 @@ func (c *Connection) QueryContext(ctx context.Context, query string, namedArgs [
 		isPseudoCommand = true
 		query = strings.Trim(query[3:], " ")
 		if strings.HasPrefix(query, "getqid") {
-			query = strings.Trim(query[7:], " ")
+			query = strings.Trim(query[6:], " ")
 		}
 	}
 	query = GetTidySQL(query)

--- a/go/connection_test.go
+++ b/go/connection_test.go
@@ -625,6 +625,16 @@ func TestMoneyWise(t *testing.T) {
 	assert.Nil(t, er)
 	assert.NotNil(t, dr)
 
+	query = "pc:getqid"
+	dr, er = c.ExecContext(context.Background(), query, []driver.NamedValue{})
+	assert.Equal(t, er, ErrInvalidQuery)
+	assert.Nil(t, dr)
+
+	query = "pc:getqid SELECTQueryContext_CANCEL_OK"
+	dr, er = c.ExecContext(context.Background(), query, []driver.NamedValue{})
+	assert.Nil(t, er)
+	assert.NotNil(t, dr)
+
 	query = "SELECTQueryContext_CANCEL_OK"
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 	defer cancel()

--- a/go/connection_test.go
+++ b/go/connection_test.go
@@ -630,6 +630,21 @@ func TestMoneyWise(t *testing.T) {
 	assert.Equal(t, er, ErrInvalidQuery)
 	assert.Nil(t, dr)
 
+	query = "pc:getqid FAILED_AFTER_GETQID"
+	dr, er = c.ExecContext(context.Background(), query, []driver.NamedValue{})
+	assert.Equal(t, er.Error(), "FAILED_AFTER_GETQID_FAILED")
+	assert.Nil(t, dr)
+
+	query = "pc:getqid FAILED_AFTER_GETQID2"
+	dr, er = c.ExecContext(context.Background(), query, []driver.NamedValue{})
+	assert.Nil(t, er)
+	assert.NotNil(t, dr)
+
+	query = "pc:badcommand"
+	dr, er = c.ExecContext(context.Background(), query, []driver.NamedValue{})
+	assert.NotNil(t, er)
+	assert.Nil(t, dr)
+
 	query = "pc:getqid SELECTQueryContext_CANCEL_OK"
 	dr, er = c.ExecContext(context.Background(), query, []driver.NamedValue{})
 	assert.Nil(t, er)

--- a/go/constants.go
+++ b/go/constants.go
@@ -85,3 +85,10 @@ const (
 
 const digits01 = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
 const digits10 = "0000000000111111111122222222223333333333444444444455555555556666666666777777777788888888889999999999"
+
+// AthenaColumnTypes is a fixed array of Athena Column Types. An array isn't immutable by nature; you can't make it constant.
+var AthenaColumnTypes = [...]string{"tinyint", "smallint", "integer", "bigint", "float", "real", "double",
+	"json", "char", "varchar", "varbinary", "row", "string", "binary",
+	"struct", "interval year to month", "interval day to second", "decimal",
+	"ipaddress", "array", "map", "unknown", "boolean", "date", "time", "time with time zone",
+	"timestamp with time zone", "timestamp", "weird_type"}

--- a/go/constants.go
+++ b/go/constants.go
@@ -94,6 +94,12 @@ var AthenaColumnTypes = [...]string{"tinyint", "smallint", "integer", "bigint", 
 	"timestamp with time zone", "timestamp", "weird_type"}
 
 // pseudo commands all start with `PC_`
-const PC_GetQID = "get_query_id"
-const PC_GetQIDStatus = "get_query_id_status"
-const PC_StopQID = "stop_query_id"
+
+// PCGetQID is the pseudo command of getting query execution id of an SQL
+const PCGetQID = "get_query_id"
+
+// PCGetQIDStatus is the pseudo command of getting status of a query execution id
+const PCGetQIDStatus = "get_query_id_status"
+
+// PCStopQID is the pseudo command to stop a query execution id
+const PCStopQID = "stop_query_id"

--- a/go/constants.go
+++ b/go/constants.go
@@ -92,3 +92,8 @@ var AthenaColumnTypes = [...]string{"tinyint", "smallint", "integer", "bigint", 
 	"struct", "interval year to month", "interval day to second", "decimal",
 	"ipaddress", "array", "map", "unknown", "boolean", "date", "time", "time with time zone",
 	"timestamp with time zone", "timestamp", "weird_type"}
+
+// pseudo commands all start with `PC_`
+const PC_GetQID = "get_query_id"
+const PC_GetQIDStatus = "get_query_id_status"
+const PC_StopQID = "stop_query_id"

--- a/go/mockathenaclient_test.go
+++ b/go/mockathenaclient_test.go
@@ -22,7 +22,9 @@ package athenadriver
 
 import (
 	"context"
+	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/aws/aws-sdk-go/service/athena/athenaiface"
@@ -63,6 +65,7 @@ func newMockAthenaClient() *mockAthenaClient {
 			"SELECTQueryContext_OK_QID":            PingResponse,
 			"00000000-0000-0000-0000-000000000000": PingResponse,
 			"pc:getqid":                            PingResponse,
+			"FAILED_AFTER_GETQID":                  MissingDataResponse,
 		},
 	}
 	return &m
@@ -193,6 +196,19 @@ func (m *mockAthenaClient) StartQueryExecution(s *athena.
 		return &athena.StartQueryExecutionOutput{
 			QueryExecutionId: &qid,
 		}, nil
+	}
+	if *s.QueryString == "FAILED_AFTER_GETQID" {
+		qid := "FAILED_AFTER_GETQID_123"
+		return &athena.StartQueryExecutionOutput{
+			QueryExecutionId: &qid,
+		}, fmt.Errorf("FAILED_AFTER_GETQID_FAILED")
+	}
+	if *s.QueryString == "FAILED_AFTER_GETQID2" {
+		qid := "FAILED_AFTER_GETQID_123"
+		return &athena.StartQueryExecutionOutput{
+				QueryExecutionId: &qid,
+			}, awserr.NewRequestFailure(awserr.New("a", "b", fmt.Errorf("FAILED_AFTER_GETQID_FAILED")),
+				100, qid)
 	}
 	return nil, nil
 }

--- a/go/mockathenaclient_test.go
+++ b/go/mockathenaclient_test.go
@@ -64,7 +64,7 @@ func newMockAthenaClient() *mockAthenaClient {
 			"SELECTExecContext_OK_QID":             PingResponse,
 			"SELECTQueryContext_OK_QID":            PingResponse,
 			"00000000-0000-0000-0000-000000000000": PingResponse,
-			"pc:getqid":                            PingResponse,
+			"pc:get_query_id":                      PingResponse,
 			"FAILED_AFTER_GETQID":                  MissingDataResponse,
 		},
 	}
@@ -348,6 +348,25 @@ func (m *mockAthenaClient) GetQueryExecutionWithContext(c aws.Context,
 			},
 		}, nil
 	}
+	if *input.QueryExecutionId == "c89088ab-595d-4ee6-a9ce-73b55aeb8900" {
+		ping := "SELECTQueryContext_CANCEL_OK_QID"
+		stat := athena.QueryExecutionStateQueued
+		stt := "DDL"
+		var dataScanned = int64(123)
+		return &athena.GetQueryExecutionOutput{
+			QueryExecution: &athena.QueryExecution{
+				Query:            &ping,
+				QueryExecutionId: &ping,
+				Status: &athena.QueryExecutionStatus{
+					State: &stat,
+				},
+				StatementType: &stt,
+				Statistics: &athena.QueryExecutionStatistics{
+					DataScannedInBytes: &dataScanned,
+				},
+			},
+		}, nil
+	}
 	return nil, ErrTestMockGeneric
 }
 
@@ -357,6 +376,12 @@ func (m *mockAthenaClient) StopQueryExecutionWithContext(ctx aws.Context, input 
 		return &athena.StopQueryExecutionOutput{}, nil
 	}
 	if *input.QueryExecutionId == "SELECTQueryContext_CANCEL_FAIL_QID" {
+		return nil, ErrTestMockGeneric
+	}
+	if *input.QueryExecutionId == "c89088ab-595d-4ee6-a9ce-73b55aeb8954" {
+		return &athena.StopQueryExecutionOutput{}, nil
+	}
+	if *input.QueryExecutionId == "c89088ab-595d-4ee6-a9ce-73b55aeb8955" {
 		return nil, ErrTestMockGeneric
 	}
 	return nil, ErrTestMockGeneric

--- a/go/mockathenaclient_test.go
+++ b/go/mockathenaclient_test.go
@@ -62,6 +62,7 @@ func newMockAthenaClient() *mockAthenaClient {
 			"SELECTExecContext_OK_QID":             PingResponse,
 			"SELECTQueryContext_OK_QID":            PingResponse,
 			"00000000-0000-0000-0000-000000000000": PingResponse,
+			"pc:getqid":                            PingResponse,
 		},
 	}
 	return &m

--- a/go/mockathenaclient_test.go
+++ b/go/mockathenaclient_test.go
@@ -350,18 +350,18 @@ func MultiplePagesQueryResponse(token string) (*athena.GetQueryResultsOutput, er
 	switch token {
 	case "":
 		var nextToken = "a1"
-		return newHeaderResultPage(columns, &nextToken, 6), nil
+		return newRandomHeaderResultPage(columns, &nextToken, 6), nil
 	case "a1":
 		nextToken := "a2"
-		return newHeaderlessResultPage(columns, &nextToken, 10), nil
+		return newRandomHeaderlessResultPage(columns, &nextToken, 10), nil
 	case "a2":
 		nextToken := "a3"
-		return newHeaderlessResultPage(columns, &nextToken, 5), nil
+		return newRandomHeaderlessResultPage(columns, &nextToken, 5), nil
 	case "a3":
 		nextToken := "a4"
-		return newHeaderlessResultPage(columns, &nextToken, 5), nil
+		return newRandomHeaderlessResultPage(columns, &nextToken, 5), nil
 	case "a4":
-		return newHeaderlessResultPage(columns, nil, 10), nil
+		return newRandomHeaderlessResultPage(columns, nil, 10), nil
 	default:
 		return nil, ErrTestMockGeneric
 	}
@@ -374,18 +374,18 @@ func MultiplePagesQueryFailedResponse(token string) (*athena.GetQueryResultsOutp
 	switch token {
 	case "":
 		var nextToken = "a1"
-		return newHeaderResultPage(columns, &nextToken, 6), nil
+		return newRandomHeaderResultPage(columns, &nextToken, 6), nil
 	case "a1":
 		nextToken := "a2"
-		return newHeaderlessResultPage(columns, &nextToken, 3), nil
+		return newRandomHeaderlessResultPage(columns, &nextToken, 3), nil
 	case "a2":
 		nextToken := "a3"
-		return newHeaderlessResultPage(columns, &nextToken, 5), nil
+		return newRandomHeaderlessResultPage(columns, &nextToken, 5), nil
 	case "a3":
 		nextToken := "GetQueryResultsWithContext_return_error"
-		return newHeaderlessResultPage(columns, &nextToken, 5), nil
+		return newRandomHeaderlessResultPage(columns, &nextToken, 5), nil
 	case "a4":
-		return newHeaderlessResultPage(columns, nil, 10), nil
+		return newRandomHeaderlessResultPage(columns, nil, 10), nil
 	default:
 		return nil, ErrTestMockGeneric
 	}
@@ -398,18 +398,18 @@ func MultiplePagesEmptyRowInPageResponse(token string) (*athena.GetQueryResultsO
 	switch token {
 	case "":
 		var nextToken = "a1"
-		return newHeaderResultPage(columns, &nextToken, 6), nil
+		return newRandomHeaderResultPage(columns, &nextToken, 6), nil
 	case "a1":
 		nextToken := "a2"
-		return newHeaderlessResultPage(columns, &nextToken, 0), nil
+		return newRandomHeaderlessResultPage(columns, &nextToken, 0), nil
 	case "a2":
 		nextToken := "a3"
-		return newHeaderlessResultPage(columns, &nextToken, 5), nil
+		return newRandomHeaderlessResultPage(columns, &nextToken, 5), nil
 	case "a3":
 		nextToken := "GetQueryResultsWithContext_return_error"
-		return newHeaderlessResultPage(columns, &nextToken, 5), nil
+		return newRandomHeaderlessResultPage(columns, &nextToken, 5), nil
 	case "a4":
-		return newHeaderlessResultPage(columns, nil, 10), nil
+		return newRandomHeaderlessResultPage(columns, nil, 10), nil
 	default:
 		return nil, ErrTestMockGeneric
 	}
@@ -419,7 +419,7 @@ func ShowResponse(_ string) (*athena.GetQueryResultsOutput, error) {
 	columns := []*athena.ColumnInfo{
 		newColumnInfo("partition", "string"),
 	}
-	return newHeaderResultPage(columns, nil, 6), nil
+	return newRandomHeaderResultPage(columns, nil, 6), nil
 }
 
 func OneColumnZeroRowResponse(token string) (*athena.GetQueryResultsOutput,
@@ -606,7 +606,7 @@ func NextFailedResponse(token string) (*athena.GetQueryResultsOutput, error) {
 	switch token {
 	case "":
 		var nextToken = "p1"
-		return newHeaderResultPage(columns, &nextToken, 5), nil
+		return newRandomHeaderResultPage(columns, &nextToken, 5), nil
 	default:
 		return nil, ErrTestMockGeneric
 	}

--- a/go/rows.go
+++ b/go/rows.go
@@ -49,6 +49,20 @@ type Rows struct {
 	pageCount       int64
 }
 
+// NewNonOpsRows is to create a new Rows.
+func NewNonOpsRows(ctx context.Context, athenaAPI athenaiface.AthenaAPI, queryID string, driverConfig *Config,
+	obs *DriverTracer) (*Rows, error) {
+	r := Rows{
+		athena:    athenaAPI,
+		ctx:       ctx,
+		queryID:   queryID,
+		config:    driverConfig,
+		tracer:    obs,
+		pageCount: -1,
+	}
+	return &r, nil
+}
+
 // NewRows is to create a new Rows.
 func NewRows(ctx context.Context, athenaAPI athenaiface.AthenaAPI, queryID string, driverConfig *Config,
 	obs *DriverTracer) (*Rows, error) {

--- a/go/utils.go
+++ b/go/utils.go
@@ -543,7 +543,7 @@ func isQueryTimeOut(startOfStartQueryExecution time.Time, queryType string) bool
 // isQueryValid is to check the validity of Query, now only string length check.
 // https://docs.aws.amazon.com/athena/latest/ug/service-limits.html
 func isQueryValid(query string) bool {
-	return len(query) < MAXQueryStringLength
+	return len(query) < MAXQueryStringLength && len(query) > 4
 }
 
 // GetFromEnvVal is to get environmental variable value by keys.

--- a/go/utils.go
+++ b/go/utils.go
@@ -347,7 +347,61 @@ func missingDataRow(columns []*athena.ColumnInfo) *athena.Row {
 	return row
 }
 
-func newHeaderResultPage(columns []*athena.ColumnInfo, nextToken *string,
+func genRow(rowData []*string) *athena.Row {
+	row := &athena.Row{
+		Data: make([]*athena.Datum, len(rowData)),
+	}
+	for i := 0; i < len(rowData); i++ {
+		row.Data[i] = &athena.Datum{VarCharValue: rowData[i]}
+	}
+	return row
+}
+
+// columnTypes must be from one of AthenaColumnTypes
+func newHeaderResultPage(columnNames []*string, columnTypes []string, rowsData [][]*string) *athena.GetQueryResultsOutput {
+	columns := make([]*athena.ColumnInfo, len(columnNames))
+	for i := 0; i < len(columnNames); i++ {
+		columns[i] = newColumnInfo(*columnNames[i], columnTypes[i])
+	}
+	rowLen := len(rowsData)
+	rows := make([]*athena.Row, rowLen+1)
+	rows[0] = genHeaderRow(columns)
+	for i := 1; i < rowLen+1; i++ {
+		rows[i] = genRow(rowsData[i])
+	}
+	return &athena.GetQueryResultsOutput{
+		NextToken: nil,
+		ResultSet: &athena.ResultSet{
+			ResultSetMetadata: &athena.ResultSetMetadata{
+				ColumnInfo: columns,
+			},
+			Rows: rows,
+		},
+	}
+}
+
+func newHeaderlessResultPage(columnNames []*string, columnTypes []string, rowsData [][]*string) *athena.GetQueryResultsOutput {
+	columns := make([]*athena.ColumnInfo, len(columnNames))
+	for i := 0; i < len(columnNames); i++ {
+		columns[i] = newColumnInfo(*columnNames[i], columnTypes[i])
+	}
+	rowLen := len(rowsData)
+	rows := make([]*athena.Row, rowLen)
+	for i := 0; i < rowLen; i++ {
+		rows[i] = genRow(rowsData[i])
+	}
+	return &athena.GetQueryResultsOutput{
+		NextToken: nil,
+		ResultSet: &athena.ResultSet{
+			ResultSetMetadata: &athena.ResultSetMetadata{
+				ColumnInfo: columns,
+			},
+			Rows: rows,
+		},
+	}
+}
+
+func newRandomHeaderResultPage(columns []*athena.ColumnInfo, nextToken *string,
 	rowLen int) *athena.GetQueryResultsOutput {
 	rows := make([]*athena.Row, rowLen)
 	rows[0] = genHeaderRow(columns)
@@ -365,7 +419,7 @@ func newHeaderResultPage(columns []*athena.ColumnInfo, nextToken *string,
 	}
 }
 
-func newHeaderlessResultPage(columns []*athena.ColumnInfo, nextToken *string,
+func newRandomHeaderlessResultPage(columns []*athena.ColumnInfo, nextToken *string,
 	rowLen int) *athena.GetQueryResultsOutput {
 	rows := make([]*athena.Row, rowLen)
 	for i := 0; i < rowLen; i++ {

--- a/go/utils.go
+++ b/go/utils.go
@@ -367,7 +367,7 @@ func newHeaderResultPage(columnNames []*string, columnTypes []string, rowsData [
 	rows := make([]*athena.Row, rowLen+1)
 	rows[0] = genHeaderRow(columns)
 	for i := 1; i < rowLen+1; i++ {
-		rows[i] = genRow(rowsData[i])
+		rows[i] = genRow(rowsData[i-1])
 	}
 	return &athena.GetQueryResultsOutput{
 		NextToken: nil,

--- a/go/utils_test.go
+++ b/go/utils_test.go
@@ -133,12 +133,7 @@ func TestRandRow(t *testing.T) {
 	assert.Equal(t, len(r.Data), 1)
 	assert.Equal(t, *r.Data[0].VarCharValue, "a\tb")
 
-	types := []string{"tinyint", "smallint", "integer", "bigint", "float", "real", "double",
-		"json", "char", "varchar", "varbinary", "row", "string", "binary",
-		"struct", "interval year to month", "interval day to second", "decimal",
-		"ipaddress", "array", "map", "unknown", "boolean", "date", "time", "time with time zone",
-		"timestamp with time zone", "timestamp", "weird_type"}
-	for _, ty := range types {
+	for _, ty := range AthenaColumnTypes {
 		c1 := newColumnInfo("c1", ty)
 		r := randRow([]*athena.ColumnInfo{c1})
 		assert.Equal(t, len(r.Data), 1)

--- a/go/utils_test.go
+++ b/go/utils_test.go
@@ -406,3 +406,14 @@ func TestUtils_IsQID(t *testing.T) {
 	assert.False(t, IsQID("a44f8e61-4cbb-429a-b7ab-bea2c4a5caeD"))
 	assert.False(t, IsQID("a44f8e61"))
 }
+
+func Test_newHeaderResultPage(t *testing.T) {
+	colName := "_col0"
+	qid := "123"
+	columnNames := []*string{&colName}
+	columnTypes := []string{"string"}
+	data := make([][]*string, 1)
+	data[0] = []*string{&qid}
+	page := newHeaderResultPage(columnNames, columnTypes, data)
+	assert.NotNil(t, page)
+}


### PR DESCRIPTION
Sample:

`pc:get_query_id SQL_STATEMENT` - Will return Query ID of the `SQL_STATEMENT`, no matter request fails or succeeds.

`pc:get_query_id_status QID` - Return status of the Query ID

`pc:stop_query_id QID` - To stop the Query corresponding the query id
