### PR TITLE
url.Parse's result has a slash as the prefix in the Path member variable

### DIFF
--- a/go/config.go
+++ b/go/config.go
@@ -270,9 +270,8 @@ func (c *Config) GetUser() string {
 func (c *Config) GetOutputBucket() string {
 	if strings.HasPrefix(c.dsn.Path, "/") {
 		return c.dsn.Scheme + "://" + c.dsn.Host + c.dsn.Path
-	} else {
-		return c.dsn.Scheme + "://" + c.dsn.Host + "/" + c.dsn.Path
 	}
+	return c.dsn.Scheme + "://" + c.dsn.Host + "/" + c.dsn.Path
 }
 
 // GetWorkgroup is getter of Workgroup.

--- a/go/config.go
+++ b/go/config.go
@@ -268,7 +268,11 @@ func (c *Config) GetUser() string {
 
 // GetOutputBucket is getter of OutputBucket.
 func (c *Config) GetOutputBucket() string {
-	return c.dsn.Scheme + "://" + c.dsn.Host + "/" + c.dsn.Path
+	if strings.HasPrefix(c.dsn.Path, "/") {
+		return c.dsn.Scheme + "://" + c.dsn.Host + c.dsn.Path
+	} else {
+		return c.dsn.Scheme + "://" + c.dsn.Host + "/" + c.dsn.Path
+	}
 }
 
 // GetWorkgroup is getter of Workgroup.

--- a/go/config_test.go
+++ b/go/config_test.go
@@ -57,6 +57,16 @@ func TestAthenaConfig(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestGetOutputBucket(t *testing.T) {
+	var s3bucket string = "s3://query-results-henry-wu-us-east-2/local/"
+	testConf := NewNoOpsConfig()
+	err := testConf.SetOutputBucket(s3bucket)
+	conf, _ := NewConfig(testConf.Stringify())
+	assert.Nil(t, err)
+	assert.Equal(t, testConf.GetOutputBucket(), "s3://query-results-henry-wu-us-east-2/local/")
+	assert.Equal(t, conf.GetOutputBucket(), "s3://query-results-henry-wu-us-east-2/local/")
+}
+
 func TestAthenaConfigWrongS3Bucket(t *testing.T) {
 	var s3bucket string = "file:///query-results-henry-wu-us-east-2/"
 	testConf := NewNoOpsConfig()


### PR DESCRIPTION
`url.Parse(s)` will return a result of `*URL`, which has a `/` as the prefix in the `Path` member variable. We need to consider it when constructing an AWS S3 path, which is very restrict with the slash.