### PR TITLE
If the query is a QID, it is readonly.

### DIFF
--- a/go/utils.go
+++ b/go/utils.go
@@ -146,7 +146,8 @@ func isReadOnlyStatement(query string) bool {
 		strings.Index(nQuery, "using") == 0 ||
 		strings.Index(nQuery, "with") == 0 ||
 		strings.Index(nQuery, "desc") == 0 ||
-		strings.Index(nQuery, "show") == 0
+		strings.Index(nQuery, "show") == 0 ||
+		IsQID(query)
 }
 
 func isInsertStatement(query string) bool {


### PR DESCRIPTION
fix https://github.com/uber/athenadriver/issues/12