### PR TITLE
[AthenaReader]Add multiple queries support and fastfail mode

### DIFF
--- a/lib/queryfx/module.go
+++ b/lib/queryfx/module.go
@@ -51,7 +51,7 @@ type QueryAndDBConnection struct {
 	// DB is the pointer to sql/database DB
 	DB *sql.DB
 	// Query is the query string
-	Query string
+	Query []string
 }
 
 func new(p Params) (Result, error) {


### PR DESCRIPTION
Now Athenareader can send multiple queries in a row.

You just need to put all your queries in a text file and separate them with an empty line, like:

```
delete database a;

create database a;

create table b ...;

select * from b;
```

A new command-line argument `-f` is added, which means the `fast fail` mode. The program exits when it encounters the first error in fast fail mode. If it's disabled by `--f=false`, the program will run all the SQLs in the file. By default, fast fail is enabled.