### PR TITLE
Use exact match for QID

### DIFF
--- a/go/utils.go
+++ b/go/utils.go
@@ -743,7 +743,7 @@ var multiLineCommentPattern = regexp.MustCompile(`\/\*(.*)\*/\s*`)
 var oneLineCommentPattern = regexp.MustCompile(`(^\-\-[^\n]+|\s--[^\n]+)`)
 var getTableNamePattern = regexp.MustCompile(`(?i)\s+(?:from|join)\s+([\w.]+)`)
 var dualPattern = regexp.MustCompile(`from dual`)
-var qIDPattern = regexp.MustCompile(`[0-9a-f-]{36}`)
+var qIDPattern = regexp.MustCompile(`^[0-9a-f-]{36}$`)
 
 // GetTableNamesInQuery is a pessimistic function to return tables involved in query in format of DB.TABLE
 // https://regoio.herokuapp.com/

--- a/go/utils_test.go
+++ b/go/utils_test.go
@@ -439,6 +439,7 @@ func TestUilts_GetCost(t *testing.T) {
 }
 
 func TestUtils_IsQID(t *testing.T) {
+	assert.False(t, IsQID(`select "a44f8e61-4cbb-429a-b7ab-bea2c4a5caed"`))
 	assert.True(t, IsQID("a44f8e61-4cbb-429a-b7ab-bea2c4a5caed"))
 	assert.False(t, IsQID("a44f8e61-4cbb-429a-b7ab-bea2c4a5caeD"))
 	assert.False(t, IsQID("a44f8e61"))


### PR DESCRIPTION
Go's MatchString is not exact match, more like ContainString. This PR is to fix it.

fix #30 