### PR TITLE
aws-sdk-go updated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.4.1
-	github.com/aws/aws-sdk-go v1.31.11
+	github.com/aws/aws-sdk-go v1.37.32
 	github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c
 	github.com/go-openapi/strfmt v0.19.5 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible


### PR DESCRIPTION
We are using aws sso features on our local machines, so we needed to enable this feature on this library, that's why we updated aws-go-sdk