### PR TITLE
Release v1.1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
   include:
   - go: 1.12.x
   - go: 1.13.x
+  - go: 1.14.x
+  - go: 1.15.x
+  - go: 1.16.x
     env: LINT=1
 
 install:

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,7 @@
+v1.1.13 - Merge community contribution (July 16, 2021)
+    - Overriding Athena Service Limits for Query Timeout
+    - README cleanup
+
 v1.1.12 - Minor bug fix and more documentation (October 29, 2020)
     - Use exact match for Query ID search
 

--- a/README.md
+++ b/README.md
@@ -1163,7 +1163,7 @@ For the contributors, the following is `athenadriver` Package's UML Class Diagra
 [cov-img]: https://codecov.io/gh/uber/athenadriver/branch/master/graph/badge.svg
 [cov]: https://codecov.io/gh/uber/athenadriver
 
-[release-img]: https://img.shields.io/badge/release-v1.1.12-red
+[release-img]: https://img.shields.io/badge/release-v1.1.13-red
 [release]: https://github.com/uber/athenadriver/releases
 
 [report-card-img]: https://goreportcard.com/badge/github.com/uber/athenadriver

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 [![CodeCov][cov-img]][cov]
 [![GoDoc][doc-img]][doc]
 [![Github release][release-img]][release]
-[![Build Status][ci-img]][ci]
-[![FOSSA][fossa-img]][fossa]
 [![Go Report Card][report-card-img]][report-card]
 [![lic][license-img]][license]
 [![made][made-img]][made]
@@ -1154,7 +1152,7 @@ For the contributors, the following is `athenadriver` Package's UML Class Diagra
 
 ----
 
-`athenadriver` is brought to you by Uber ATG Infrastructure. Copyright (c) 2020 Uber Technologies, Inc. ![](resources/atg-infra.png)
+`athenadriver` is brought to you by Uber. Copyright (c) 2020 Uber Technologies, Inc.
 
 
 
@@ -1179,6 +1177,6 @@ For the contributors, the following is `athenadriver` Package's UML Class Diagra
 
 [release-policy]: https://golang.org/doc/devel/release.html#policy
 
-[made-img]: https://img.shields.io/badge/By-Uber%20ATG-red
-[made]: https://www.uber.com/us/en/atg/
+[made-img]: https://img.shields.io/badge/By-Uber%20Tech-red
+[made]: https://www.uber.com
 

--- a/athenareader/go.mod
+++ b/athenareader/go.mod
@@ -3,6 +3,6 @@ module github.com/uber/athenadriver/athenareader
 go 1.13
 
 require (
-	github.com/uber/athenadriver v1.1.12
+	github.com/uber/athenadriver v1.1.13
 	go.uber.org/fx v1.12.0
 )

--- a/go/constants.go
+++ b/go/constants.go
@@ -108,4 +108,4 @@ const PCStopQID = "stop_query_id"
 const PCGetDriverVersion = "get_driver_version"
 
 // DriverVersion is athenadriver's version
-const DriverVersion = "1.1.12"
+const DriverVersion = "1.1.13"

--- a/go/errors.go
+++ b/go/errors.go
@@ -42,5 +42,5 @@ var (
 	ErrAthenaNilAPI                 = errors.New("athenaAPI must not be nil")
 	ErrTestMockGeneric              = errors.New("some_mock_error_for_test")
 	ErrTestMockFailedByAthena       = errors.New("the reason why Athena failed the query")
-	ErrServiceLimitOverride         = errors.New(fmt.Sprintf("service limit override must be greater than %d", PoolInterval))
+	ErrServiceLimitOverride         = fmt.Errorf("service limit override must be greater than %d", PoolInterval)
 )


### PR DESCRIPTION
```
Release v1.1.13
v1.1.13 - Merge community contribution (July 16, 2021)
    - Overriding Athena Service Limits for Query Timeout
    - README cleanup
```