### PR TITLE
Expose DriverTracer factory functions

### DIFF
--- a/go/connection_test.go
+++ b/go/connection_test.go
@@ -24,14 +24,15 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"math/rand"
+	"testing"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/stretchr/testify/assert"
-	"math/rand"
-	"testing"
-	"time"
 )
 
 var regions = []string{"ap-east-1", "eu-central-1", "eu-north-1", "eu-west-1", "eu-west-2", "eu-west-3",
@@ -111,7 +112,7 @@ func TestConnection_Prepare(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 
 	conn, err := connector.Connect(context.Background())
@@ -131,7 +132,7 @@ func TestConnection_Begin(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 
 	conn, err := connector.Connect(context.Background())
@@ -146,7 +147,7 @@ func TestConnection_Close(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 
 	conn, err := connector.Connect(context.Background())
@@ -160,7 +161,7 @@ func TestConnection_QueryContext(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 
 	conn, err := connector.Connect(context.Background())

--- a/go/connector.go
+++ b/go/connector.go
@@ -23,7 +23,7 @@ package athenadriver
 import (
 	"context"
 	"database/sql/driver"
-	"github.com/aws/aws-sdk-go/aws/credentials"
+
 	"os"
 	"strconv"
 	"time"
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/athena"
 )
@@ -47,7 +48,7 @@ func NoopsSQLConnector() *SQLConnector {
 	noopsConfig := NewNoOpsConfig()
 	return &SQLConnector{
 		config: noopsConfig,
-		tracer: newDefaultObservability(noopsConfig),
+		tracer: NewDefaultObservability(noopsConfig),
 	}
 }
 
@@ -64,7 +65,7 @@ func (c *SQLConnector) Driver() driver.Driver {
 // Ref: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html
 func (c *SQLConnector) Connect(ctx context.Context) (driver.Conn, error) {
 	now := time.Now()
-	c.tracer = newDefaultObservability(c.config)
+	c.tracer = NewDefaultObservability(c.config)
 	if metrics, ok := ctx.Value(MetricsKey).(tally.Scope); ok {
 		c.tracer.SetScope(metrics)
 	}

--- a/go/connector_test.go
+++ b/go/connector_test.go
@@ -22,19 +22,20 @@ package athenadriver
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
-	"github.com/uber-go/tally"
-	"go.uber.org/zap"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 )
 
 func TestSQLConnector(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 
 	conn, err := connector.Connect(context.Background())
@@ -52,7 +53,7 @@ func TestSQLConnector_Connect(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 
 	logger, _ := zap.NewProduction()
@@ -79,7 +80,7 @@ func TestSQLConnector_Connect_NewSessionFail(t *testing.T) {
 	os.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "123")
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 	conn, err := connector.Connect(context.Background())
 
@@ -95,7 +96,7 @@ func TestSQLConnector_Connect_NewSession_AWS_SDK_LOAD_CONFIG_true(t *testing.T) 
 	os.Setenv("AWS_SDK_LOAD_CONFIG", "true")
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 	conn, err := connector.Connect(context.Background())
 
@@ -112,7 +113,7 @@ func TestSQLConnector_Connect_NewSession_AWS_SDK_LOAD_CONFIG_true_AWSProfile_Set
 	os.Setenv("AWS_SDK_LOAD_CONFIG", "true")
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 	conn, err := connector.Connect(context.Background())
 
@@ -128,7 +129,7 @@ func TestSQLConnector_Connect_NewSession_AWS_SDK_LOAD_CONFIG_false(t *testing.T)
 	os.Setenv("AWS_SDK_LOAD_CONFIG", "0")
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 	conn, err := connector.Connect(context.Background())
 
@@ -142,7 +143,7 @@ func TestSQLConnector_Driver(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 	assert.NotNil(t, connector.Driver())
 }

--- a/go/rows_test.go
+++ b/go/rows_test.go
@@ -60,7 +60,7 @@ func TestOnePageSuccess(t *testing.T) {
 	}
 	for _, test := range tests {
 		r, _ := NewRows(context.Background(), newMockAthenaClient(),
-			test.queryID, testConf, newDefaultObservability(testConf))
+			test.queryID, testConf, NewDefaultObservability(testConf))
 
 		var testArray, firstName, lastName string
 		var active bool
@@ -105,7 +105,7 @@ func TestNextFailure(t *testing.T) {
 	for _, test := range tests {
 		r, _ := NewRows(context.Background(), newMockAthenaClient(),
 			test.queryID,
-			testConf, newDefaultObservability(testConf))
+			testConf, NewDefaultObservability(testConf))
 
 		var testArray, firstName, lastName string
 		var active bool
@@ -150,7 +150,7 @@ func TestMultiplePages(t *testing.T) {
 	for _, test := range tests {
 		r, _ = NewRows(context.Background(), newMockAthenaClient(),
 			test.queryID,
-			testConf, newDefaultObservability(testConf))
+			testConf, NewDefaultObservability(testConf))
 
 		var testArray, firstName, lastName string
 		var active bool
@@ -197,7 +197,7 @@ func TestRows_Columns(t *testing.T) {
 	for _, test := range tests {
 		r, _ := NewRows(context.Background(), newMockAthenaClient(),
 			test.queryID,
-			testConf, newDefaultObservability(testConf))
+			testConf, NewDefaultObservability(testConf))
 		assert.Equal(t, len(r.Columns()), len(cs))
 	}
 }
@@ -221,7 +221,7 @@ func TestRows_ColumnTypeDatabaseTypeName(t *testing.T) {
 	for _, test := range tests {
 		r, _ := NewRows(context.Background(), newMockAthenaClient(),
 			test.queryID,
-			testConf, newDefaultObservability(testConf))
+			testConf, NewDefaultObservability(testConf))
 		for i, v := range cs {
 			assert.Equal(t, r.ColumnTypeDatabaseTypeName(i), *v.Type)
 
@@ -248,7 +248,7 @@ func TestRows_GetDefaultValueForColumnType(t *testing.T) {
 	for _, test := range tests {
 		r, _ := NewRows(context.Background(), newMockAthenaClient(),
 			test.queryID,
-			testConf, newDefaultObservability(testConf))
+			testConf, NewDefaultObservability(testConf))
 		for _, v := range []string{"tinyint", "smallint", "integer", "bigint"} {
 			assert.Equal(t, r.getDefaultValueForColumnType(v), 0)
 		}
@@ -271,7 +271,7 @@ func TestRows_GetDefaultValueForColumnType(t *testing.T) {
 func TestRows_AthenaTypeToGoType(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	r, _ := NewRows(context.Background(), newMockAthenaClient(),
-		"SELECT_OK", testConf, newDefaultObservability(testConf))
+		"SELECT_OK", testConf, NewDefaultObservability(testConf))
 	c := newColumnInfo("a", "tinyint")
 	// tinyint
 	rv := "1"
@@ -437,7 +437,7 @@ func TestRows_AthenaTypeToGoType(t *testing.T) {
 func TestRows_ColumnTypeDatabaseTypeName2(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	r, _ := NewRows(context.Background(), newMockAthenaClient(),
-		"SELECT_OK", testConf, newDefaultObservability(testConf))
+		"SELECT_OK", testConf, NewDefaultObservability(testConf))
 	c := newColumnInfo("a", nil)
 	getQueryResultsOutput := &athena.GetQueryResultsOutput{
 		ResultSet: &athena.ResultSet{
@@ -456,39 +456,39 @@ func TestRows_NewRows(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	r, e := NewRows(context.Background(), newMockAthenaClient(),
 		"1coloumn0row",
-		testConf, newDefaultObservability(testConf))
+		testConf, NewDefaultObservability(testConf))
 	assert.Nil(t, e)
 	assert.NotNil(t, r)
 
 	r, e = NewRows(context.Background(), newMockAthenaClient(),
 		"1coloumn0row_valid",
-		testConf, newDefaultObservability(testConf))
+		testConf, NewDefaultObservability(testConf))
 	assert.Nil(t, e)
 	assert.Equal(t, *r.ResultOutput.ResultSet.Rows[0].Data[0].VarCharValue,
 		"1024")
 
 	r, e = NewRows(context.Background(), newMockAthenaClient(),
 		"column_more_than_row_fields",
-		testConf, newDefaultObservability(testConf))
+		testConf, NewDefaultObservability(testConf))
 	assert.Nil(t, e)
 	assert.NotNil(t, r)
 
 	r, e = NewRows(context.Background(), newMockAthenaClient(),
 		"row_fields_more_than_column",
-		testConf, newDefaultObservability(testConf))
+		testConf, NewDefaultObservability(testConf))
 	assert.Nil(t, e)
 	assert.NotNil(t, r)
 
 	r, e = NewRows(context.Background(), newMockAthenaClient(),
 		"GetQueryResultsWithContext_return_error",
-		testConf, newDefaultObservability(testConf))
+		testConf, NewDefaultObservability(testConf))
 	assert.NotNil(t, e)
 	assert.Nil(t, r)
 
 	// rawValue is nil
 	r, e = NewRows(context.Background(), newMockAthenaClient(),
 		"missing_data_resp",
-		testConf, newDefaultObservability(testConf))
+		testConf, NewDefaultObservability(testConf))
 	assert.Nil(t, e)
 	assert.NotNil(t, r)
 	var dest []driver.Value = make([]driver.Value, 8)
@@ -500,7 +500,7 @@ func TestRows_NewRows(t *testing.T) {
 	testConf.SetMissingAsDefault(false)
 	r, e = NewRows(context.Background(), newMockAthenaClient(),
 		"missing_data_resp",
-		testConf, newDefaultObservability(testConf))
+		testConf, NewDefaultObservability(testConf))
 	assert.Nil(t, e)
 	assert.NotNil(t, r)
 	e = r.Next(dest)
@@ -508,7 +508,7 @@ func TestRows_NewRows(t *testing.T) {
 
 	r, e = NewRows(context.Background(), newMockAthenaClient(),
 		"missing_data_resp2",
-		testConf, newDefaultObservability(testConf))
+		testConf, NewDefaultObservability(testConf))
 	assert.Nil(t, e)
 	assert.NotNil(t, r)
 	e = r.Next(dest)
@@ -517,7 +517,7 @@ func TestRows_NewRows(t *testing.T) {
 	// error when row.Next()
 	r, e = NewRows(context.Background(), newMockAthenaClient(),
 		"SELECT_GetQueryResults_ERR",
-		testConf, newDefaultObservability(testConf))
+		testConf, NewDefaultObservability(testConf))
 	assert.Nil(t, e)
 	assert.NotNil(t, r)
 	for {
@@ -531,7 +531,7 @@ func TestRows_NewRows(t *testing.T) {
 	// missing row in page
 	r, e = NewRows(context.Background(), newMockAthenaClient(),
 		"SELECT_EMPTY_ROW_IN_PAGE",
-		testConf, newDefaultObservability(testConf))
+		testConf, NewDefaultObservability(testConf))
 	assert.Nil(t, e)
 	assert.NotNil(t, r)
 	for {
@@ -545,7 +545,7 @@ func TestRows_NewRows(t *testing.T) {
 	// close in the loop
 	r, e = NewRows(context.Background(), newMockAthenaClient(),
 		"SELECT_GetQueryResults_ERR",
-		testConf, newDefaultObservability(testConf))
+		testConf, NewDefaultObservability(testConf))
 	assert.Nil(t, e)
 	assert.NotNil(t, r)
 	cnt := 0

--- a/go/statement_test.go
+++ b/go/statement_test.go
@@ -23,15 +23,16 @@ package athenadriver
 import (
 	"context"
 	"database/sql/driver"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStatement_NumInput(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 
 	conn, _ := connector.Connect(context.Background())
@@ -53,7 +54,7 @@ func TestStatement_Exec(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 
 	conn, _ := connector.Connect(context.Background())
@@ -73,7 +74,7 @@ func TestStatement_Exec_After_Close(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 
 	conn, _ := connector.Connect(context.Background())
@@ -94,7 +95,7 @@ func TestStatement_Query(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 
 	conn, _ := connector.Connect(context.Background())
@@ -114,7 +115,7 @@ func TestStatement_Query_After_Close(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 
 	conn, _ := connector.Connect(context.Background())
@@ -135,7 +136,7 @@ func TestStatement_ColumnConverter(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 
 	conn, _ := connector.Connect(context.Background())
@@ -150,7 +151,7 @@ func TestStatement_Close(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 
 	conn, _ := connector.Connect(context.Background())
@@ -167,7 +168,7 @@ func TestStatement_Close_AfterConnectionClose(t *testing.T) {
 	testConf := NewNoOpsConfig()
 	connector := &SQLConnector{
 		config: testConf,
-		tracer: newDefaultObservability(testConf),
+		tracer: NewDefaultObservability(testConf),
 	}
 
 	conn, _ := connector.Connect(context.Background())

--- a/go/trace.go
+++ b/go/trace.go
@@ -49,8 +49,8 @@ type DriverTracer struct {
 	config *Config
 }
 
-// newDefaultObservability is to create an observability object.
-func newObservability(config *Config, logger *zap.Logger,
+// NewObservability is to create an observability object.
+func NewObservability(config *Config, logger *zap.Logger,
 	scope tally.Scope) *DriverTracer {
 	o := DriverTracer{
 		logger: logger,
@@ -60,9 +60,9 @@ func newObservability(config *Config, logger *zap.Logger,
 	return &o
 }
 
-// newDefaultObservability is to create an observability object with logger
+// NewDefaultObservability is to create an observability object with logger
 // and scope as default(noops object).
-func newDefaultObservability(config *Config) *DriverTracer {
+func NewDefaultObservability(config *Config) *DriverTracer {
 	o := DriverTracer{
 		logger: zap.NewNop(),
 		scope:  tally.NoopScope,
@@ -71,8 +71,8 @@ func newDefaultObservability(config *Config) *DriverTracer {
 	return &o
 }
 
-// newNoOpsObservability is for testing purpose.
-func newNoOpsObservability() *DriverTracer {
+// NewNoOpsObservability is for testing purpose.
+func NewNoOpsObservability() *DriverTracer {
 	o := DriverTracer{
 		logger: zap.NewNop(),
 		scope:  tally.NoopScope,

--- a/go/trace_test.go
+++ b/go/trace_test.go
@@ -21,44 +21,45 @@
 package athenadriver
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestObservability_Config(t *testing.T) {
-	obs := newNoOpsObservability()
+	obs := NewNoOpsObservability()
 	assert.Equal(t, obs.Config(), NewNoOpsConfig())
 }
 
 func TestObservability_Scope(t *testing.T) {
-	obs := newNoOpsObservability()
+	obs := NewNoOpsObservability()
 	assert.Equal(t, obs.Scope(), tally.NoopScope)
 
 	config := NewNoOpsConfig()
 	config.SetMetrics(true)
-	obs = newDefaultObservability(config)
+	obs = NewDefaultObservability(config)
 	assert.Equal(t, obs.Scope(), tally.NoopScope)
 }
 
 func TestObservability_Logger(t *testing.T) {
-	obs := newNoOpsObservability()
+	obs := NewNoOpsObservability()
 	assert.Equal(t, obs.Logger(), zap.NewNop())
 
 	config := NewNoOpsConfig()
 	config.SetLogging(false)
-	obs = newDefaultObservability(config)
+	obs = NewDefaultObservability(config)
 	assert.Equal(t, obs.Logger(), zap.NewNop())
 }
 
 func TestObservability_Log(t *testing.T) {
 	config := NewNoOpsConfig()
 	config.SetLogging(false)
-	obs := newDefaultObservability(config)
+	obs := NewDefaultObservability(config)
 	obs.Log(-1, "")
 	config.SetLogging(true)
-	obs = newDefaultObservability(config)
+	obs = NewDefaultObservability(config)
 	obs.Log(-1, "")
 	obs.Log(ErrorLevel, "")
 	obs.Log(WarnLevel, "")
@@ -67,19 +68,19 @@ func TestObservability_Log(t *testing.T) {
 }
 
 func TestObservability_SetScope(t *testing.T) {
-	obs := newNoOpsObservability()
+	obs := NewNoOpsObservability()
 	obs.SetScope(tally.NoopScope)
 	assert.Equal(t, obs.Scope(), tally.NoopScope)
 }
 
 func TestObservability_SetLogger(t *testing.T) {
-	obs := newNoOpsObservability()
+	obs := NewNoOpsObservability()
 	obs.SetLogger(nil)
 	assert.Nil(t, obs.Logger())
 }
 
 func TestObservability_NewObservability(t *testing.T) {
-	obs := newObservability(NewNoOpsConfig(), zap.NewNop(), tally.NoopScope)
+	obs := NewObservability(NewNoOpsConfig(), zap.NewNop(), tally.NoopScope)
 	assert.NotNil(t, obs.Logger())
 	assert.Equal(t, obs.Logger(), zap.NewNop())
 }


### PR DESCRIPTION
Fixes #39

Exposes the functions `NewObservability`, `NewDefaultObservability` and `NewNoOpsObservability`

See more details at #39 