### PR TITLE
Add the bucket back with another name

### DIFF
--- a/go/config_test.go
+++ b/go/config_test.go
@@ -21,15 +21,14 @@
 package athenadriver
 
 import (
+	"github.com/stretchr/testify/assert"
 	"net/url"
 	"testing"
 	"time"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAthenaConfig(t *testing.T) {
-	// The Amazon S3 bucket query-results-henry-wu-us-east-2 has been compromised, and should not be used.
-	// var s3bucket string = "s3://query-results-henry-wu-us-east-2/"
+	var s3bucket string = "s3://fake-query-results-arbitrary-bucket/"
 
 	wgTags := NewWGTags()
 	wgTags.AddTag("Uber User", "henry.wu@uber.com")
@@ -46,13 +45,8 @@ func TestAthenaConfig(t *testing.T) {
 	err = testConf.SetWorkGroup(wg)
 	assert.Nil(t, err)
 	assert.Equal(t, testConf.GetUser(), "henry.wu@uber.com")
-	
-	// The Amazon S3 bucket query-results-henry-wu-us-east-2 has been compromised, and should not be used.
-	// assert.Equal(t, testConf.GetOutputBucket(), "s3://query-results-henry-wu-us-east-2/")
-	
-	// The Amazon S3 bucket query-results-henry-wu-us-east-2 has been compromised, and should not be used.
-	// expected := "s3://henry.wu%40uber.com:@query-results-henry-wu-us-east-2?WGRemoteCreation=true&db=default&missingAsEmptyString=true&region=us-east-1&tag=%7CUber+User%60henry.wu%40uber.com%7CUber+Asset%60abc.efg&workgroupConfig=%7B%0A++BytesScannedCutoffPerQuery%3A+1073741824%2C%0A++EnforceWorkGroupConfiguration%3A+true%2C%0A++PublishCloudWatchMetricsEnabled%3A+true%2C%0A++RequesterPaysEnabled%3A+false%0A%7D&workgroupName=henry_wu"
-	
+	assert.Equal(t, testConf.GetOutputBucket(), "s3://fake-query-results-arbitrary-bucket/")
+	expected := "s3://henry.wu%40uber.com:@fake-query-results-arbitrary-bucket?WGRemoteCreation=true&db=default&missingAsEmptyString=true&region=us-east-1&tag=%7CUber+User%60henry.wu%40uber.com%7CUber+Asset%60abc.efg&workgroupConfig=%7B%0A++BytesScannedCutoffPerQuery%3A+1073741824%2C%0A++EnforceWorkGroupConfiguration%3A+true%2C%0A++PublishCloudWatchMetricsEnabled%3A+true%2C%0A++RequesterPaysEnabled%3A+false%0A%7D&workgroupName=henry_wu"
 	actual := testConf.Stringify()
 	assert.Equal(t, actual, expected)
 	w := testConf.GetWorkgroup()
@@ -64,32 +58,24 @@ func TestAthenaConfig(t *testing.T) {
 }
 
 func TestGetOutputBucket(t *testing.T) {
-	// The Amazon S3 bucket query-results-henry-wu-us-east-2 has been compromised, and should not be used.
-	// var s3bucket string = "s3://query-results-henry-wu-us-east-2/local/"
-	
+	var s3bucket string = "s3://fake-query-results-arbitrary-bucket/local/"
 	testConf := NewNoOpsConfig()
 	err := testConf.SetOutputBucket(s3bucket)
 	conf, _ := NewConfig(testConf.Stringify())
 	assert.Nil(t, err)
-	
-	// The Amazon S3 bucket query-results-henry-wu-us-east-2 has been compromised, and should not be used.
-	// assert.Equal(t, testConf.GetOutputBucket(), "s3://query-results-henry-wu-us-east-2/local/")
-	// assert.Equal(t, conf.GetOutputBucket(), "s3://query-results-henry-wu-us-east-2/local/")
+	assert.Equal(t, testConf.GetOutputBucket(), "s3://fake-query-results-arbitrary-bucket/local/")
+	assert.Equal(t, conf.GetOutputBucket(), "s3://fake-query-results-arbitrary-bucket/local/")
 }
 
 func TestAthenaConfigWrongS3Bucket(t *testing.T) {
-	// The Amazon S3 bucket query-results-henry-wu-us-east-2 has been compromised, and should not be used.
-	// var s3bucket string = "file:///query-results-henry-wu-us-east-2/"
-	
+	var s3bucket string = "file:///fake-query-results-arbitrary-bucket/"
 	testConf := NewNoOpsConfig()
 	err := testConf.SetOutputBucket(s3bucket)
 	assert.NotNil(t, err)
 }
 
 func TestConfig_SetOutputBucket(t *testing.T) {
-	// The Amazon S3 bucket query-results-henry-wu-us-east-2 has been compromised, and should not be used.
-	// var s3bucket string = "s3://query-results-henry-wu-us-east-2"
-	
+	var s3bucket string = "s3://fake-query-results-arbitrary-bucket"
 	testConf := NewNoOpsConfig()
 	err := testConf.SetOutputBucket(s3bucket)
 	assert.Nil(t, err)
@@ -112,8 +98,7 @@ func TestAthenaConfigWrongWG(t *testing.T) {
 }
 
 func TestAthenaConfigSafeString(t *testing.T) {
-	// The Amazon S3 bucket query-results-henry-wu-us-east-2 has been compromised, and should not be used.
-	// var s3bucket string = "s3://query-results-henry-wu-us-east-2/"
+	var s3bucket string = "s3://fake-query-results-arbitrary-bucket/"
 
 	wg := NewDefaultWG("henry_wu", nil, nil)
 	testConf := NewNoOpsConfig()
@@ -131,12 +116,9 @@ func TestAthenaConfigSafeString(t *testing.T) {
 	assert.Nil(t, err)
 	testConf.SetSessionToken("thisisaToken")
 	assert.Equal(t, testConf.GetUser(), "henry.wu@uber.com")
-	
-	// The Amazon S3 bucket query-results-henry-wu-us-east-2 has been compromised, and should not be used.
-	// assert.Equal(t, testConf.GetOutputBucket(), "s3://query-results-henry-wu-us-east-2/")
-	
-	expectedRawString := "s3://henry.wu%40uber.com:@query-results-henry-wu-us-east-2?WGRemoteCreation=true&accessID=thisisanID&db=default&missingAsEmptyString=true&region=us-east-1&secretAccessKey=thisisaKey&sessionToken=thisisaToken&tag=&workgroupConfig=%7B%0A++BytesScannedCutoffPerQuery%3A+1073741824%2C%0A++EnforceWorkGroupConfiguration%3A+true%2C%0A++PublishCloudWatchMetricsEnabled%3A+true%2C%0A++RequesterPaysEnabled%3A+false%0A%7D&workgroupName=henry_wu"
-	expectedSafeString := "s3://henry.wu%40uber.com:@query-results-henry-wu-us-east-2?WGRemoteCreation=true&accessID=*&db=default&missingAsEmptyString=true&region=us-east-1&secretAccessKey=*&sessionToken=*&tag=&workgroupConfig=%7B%0A++BytesScannedCutoffPerQuery%3A+1073741824%2C%0A++EnforceWorkGroupConfiguration%3A+true%2C%0A++PublishCloudWatchMetricsEnabled%3A+true%2C%0A++RequesterPaysEnabled%3A+false%0A%7D&workgroupName=henry_wu"
+	assert.Equal(t, testConf.GetOutputBucket(), "s3://fake-query-results-arbitrary-bucket/")
+	expectedRawString := "s3://henry.wu%40uber.com:@fake-query-results-arbitrary-bucket?WGRemoteCreation=true&accessID=thisisanID&db=default&missingAsEmptyString=true&region=us-east-1&secretAccessKey=thisisaKey&sessionToken=thisisaToken&tag=&workgroupConfig=%7B%0A++BytesScannedCutoffPerQuery%3A+1073741824%2C%0A++EnforceWorkGroupConfiguration%3A+true%2C%0A++PublishCloudWatchMetricsEnabled%3A+true%2C%0A++RequesterPaysEnabled%3A+false%0A%7D&workgroupName=henry_wu"
+	expectedSafeString := "s3://henry.wu%40uber.com:@fake-query-results-arbitrary-bucket?WGRemoteCreation=true&accessID=*&db=default&missingAsEmptyString=true&region=us-east-1&secretAccessKey=*&sessionToken=*&tag=&workgroupConfig=%7B%0A++BytesScannedCutoffPerQuery%3A+1073741824%2C%0A++EnforceWorkGroupConfiguration%3A+true%2C%0A++PublishCloudWatchMetricsEnabled%3A+true%2C%0A++RequesterPaysEnabled%3A+false%0A%7D&workgroupName=henry_wu"
 	actualRaw := testConf.Stringify()
 	actualSafe := testConf.SafeStringify()
 	assert.Equal(t, expectedRawString, actualRaw)
@@ -314,7 +296,7 @@ func TestConfig_SetAWSProfile(t *testing.T) {
 }
 
 func TestConfig_SetServiceLimitOverride(t *testing.T) {
-	var s3bucket string = "s3://query-results-henry-wu-us-east-2/"
+	var s3bucket string = "s3://fake-query-results-arbitrary-bucket/"
 
 	testConf := NewNoOpsConfig()
 	_ = testConf.SetOutputBucket(s3bucket)
@@ -325,7 +307,7 @@ func TestConfig_SetServiceLimitOverride(t *testing.T) {
 	testServiceLimitOverride := testConf.GetServiceLimitOverride()
 	assert.Equal(t, ddlQueryTimeout, testServiceLimitOverride.GetDDLQueryTimeout())
 
-	expected := "s3://query-results-henry-wu-us-east-2?DDLQueryTimeout=60000&DMLQueryTimeout=0&WGRemoteCreation=true&db=default&missingAsEmptyString=true&region=us-east-1"
+	expected := "s3://fake-query-results-arbitrary-bucket?DDLQueryTimeout=60000&DMLQueryTimeout=0&WGRemoteCreation=true&db=default&missingAsEmptyString=true&region=us-east-1"
 	assert.Equal(t, expected, testConf.Stringify())
 
 	dmlQueryTimeout := 60 * 60 // 60 minutes
@@ -335,7 +317,7 @@ func TestConfig_SetServiceLimitOverride(t *testing.T) {
 	assert.Equal(t, ddlQueryTimeout, testServiceLimitOverride.GetDDLQueryTimeout())
 	assert.Equal(t, dmlQueryTimeout, testServiceLimitOverride.GetDMLQueryTimeout())
 
-	expected = "s3://query-results-henry-wu-us-east-2?DDLQueryTimeout=60000&DMLQueryTimeout=3600&WGRemoteCreation=true&db=default&missingAsEmptyString=true&region=us-east-1"
+	expected = "s3://fake-query-results-arbitrary-bucket?DDLQueryTimeout=60000&DMLQueryTimeout=3600&WGRemoteCreation=true&db=default&missingAsEmptyString=true&region=us-east-1"
 	assert.Equal(t, expected, testConf.Stringify())
 }
 

--- a/go/config_test.go
+++ b/go/config_test.go
@@ -21,10 +21,10 @@
 package athenadriver
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/url"
 	"testing"
 	"time"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAthenaConfig(t *testing.T) {

--- a/go/connection_test.go
+++ b/go/connection_test.go
@@ -344,8 +344,7 @@ func TestConnection_QueryContext3(t *testing.T) {
 		athenaAPI: newMockAthenaClient(),
 		connector: NoopsSQLConnector(),
 	}
-	// The Amazon S3 bucket query-results-henry-wu-us-east-2 has been compromised, and should not be used.
-	// var s3bucket string = "s3://query-results-henry-wu-us-east-2/"
+	var s3bucket string = "s3://fake-query-results-arbitrary-bucket/"
 
 	wgTags := NewWGTags()
 	wgTags.AddTag("Uber User", "henry.wu")
@@ -375,7 +374,7 @@ func TestConnection_QueryContext4(t *testing.T) {
 		athenaAPI: nm,
 		connector: NoopsSQLConnector(),
 	}
-	var s3bucket string = "s3://query-results-henry-wu-us-east-2/"
+	var s3bucket string = "s3://fake-query-results-arbitrary-bucket/"
 
 	wgTags := NewWGTags()
 	wgTags.AddTag("Uber User", "henry.wu")
@@ -408,7 +407,7 @@ func TestConnection_QueryContext5(t *testing.T) {
 		athenaAPI: nm,
 		connector: NoopsSQLConnector(),
 	}
-	var s3bucket string = "s3://query-results-henry-wu-us-east-2/"
+	var s3bucket string = "s3://fake-query-results-arbitrary-bucket/"
 
 	wgTags := NewWGTags()
 	wgTags.AddTag("Uber User", "henry.wu")
@@ -435,7 +434,7 @@ func TestConnection_QueryContext6(t *testing.T) {
 		athenaAPI: nm,
 		connector: NoopsSQLConnector(),
 	}
-	var s3bucket string = "s3://query-results-henry-wu-us-east-2/"
+	var s3bucket string = "s3://fake-query-results-arbitrary-bucket/"
 
 	wgTags := NewWGTags()
 	wgTags.AddTag("Uber User", "henry.wu")
@@ -576,7 +575,7 @@ func createConnectionFixture() *Connection {
 		athenaAPI: nm,
 		connector: NoopsSQLConnector(),
 	}
-	var s3bucket string = "s3://query-results-henry-wu-us-east-2/"
+	var s3bucket string = "s3://fake-query-results-arbitrary-bucket/"
 	wgTags := NewWGTags()
 	wgTags.AddTag("Uber Author", "henry.wu")
 	wgTags.AddTag("Uber Role", "Engineer")
@@ -600,7 +599,7 @@ func TestMoneyWise(t *testing.T) {
 		athenaAPI: newMockAthenaClient(),
 		connector: NoopsSQLConnector(),
 	}
-	var s3bucket string = "s3://query-results-henry-wu-us-east-2/"
+	var s3bucket string = "s3://fake-query-results-arbitrary-bucket/"
 
 	wgTags := NewWGTags()
 	wgTags.AddTag("Uber User", "henry.wu")
@@ -648,7 +647,7 @@ func TestConnection_CachedQuery(t *testing.T) {
 		athenaAPI: newMockAthenaClient(),
 		connector: NoopsSQLConnector(),
 	}
-	var s3bucket string = "s3://query-results-henry-wu-us-east-2/"
+	var s3bucket string = "s3://fake-query-results-arbitrary-bucket/"
 	testConf := NewNoOpsConfig()
 	err := testConf.SetOutputBucket(s3bucket)
 	assert.Nil(t, err)
@@ -670,7 +669,7 @@ func Test_PseudoCommand(t *testing.T) {
 		athenaAPI: newMockAthenaClient(),
 		connector: NoopsSQLConnector(),
 	}
-	var s3bucket string = "s3://query-results-henry-wu-us-east-2/"
+	var s3bucket string = "s3://fake-query-results-arbitrary-bucket/"
 
 	wgTags := NewWGTags()
 	wgTags.AddTag("Uber User", "henry.wu")

--- a/go/driver_test.go
+++ b/go/driver_test.go
@@ -28,12 +28,10 @@ import (
 )
 
 func TestDriver(t *testing.T) {
-	// The Amazon S3 bucket query-results-henry-wu-us-east-2 has been compromised, and should not be used.
-	// dsn := "s3://henry.wu%40uber.com:@query-results-henry-wu-us-east-2?db=default&" +
-	//	"region=us-east-1&workgroup_config=%7B%0A++BytesScannedCutoffPerQuery%3A+1073741824%2C%0A++Enfo" +
-	//	"rceWorkGroupConfiguration%3A+true%2C%0A++PublishCloudWatchMetricsEnabled%3A+true%2C%0A++Reques" +
-	//	"terPaysEnabled%3A+false%0A%7D&workgroupName=henry_wu"
-
+	dsn := "s3://henry.wu%40uber.com:@fake-query-results-arbitrary-bucket?db=default&" +
+		"region=us-east-1&workgroup_config=%7B%0A++BytesScannedCutoffPerQuery%3A+1073741824%2C%0A++Enfo" +
+		"rceWorkGroupConfiguration%3A+true%2C%0A++PublishCloudWatchMetricsEnabled%3A+true%2C%0A++Reques" +
+		"terPaysEnabled%3A+false%0A%7D&workgroupName=henry_wu"
 	pDB, err := sql.Open(DriverName, dsn)
 	assert.Nil(t, err)
 	assert.NotNil(t, pDB)


### PR DESCRIPTION
Actually the name of the bucket can be any arbitrary name and the test result won't be affected. It will not connect to AWS at all. So even if the S3 is down, the test code should still work. Why the bucket was compromised is unclear to and beyond us, but we do need a name in our test code. Since we do need it there, let's add it back with another name. Thanks.

The test result after this change:

```
$go test
1,2,3
a,b,c
hello,world,athenadriver
one,two,three
1,2,3
a,b,c
hello,world,athenadriver
one,two,three
1,2,3
a,b,c
hello,world,athenadriver
query cost: 0.0 USD, scanned data: 0 B, qid: NA
query cost: 0.0 USD, scanned data: 0 B, qid: NA
query cost: 0.0 USD, scanned data: 0 B, qid: NA
query cost: 0.0 USD, scanned data: 0 B, qid: NA
query cost: 0.00004768371582031250 USD, scanned data: 123 B, qid: SELECTExecContext_OK_QID
query cost: 56.14164421538589522243 USD, scanned data: 12345678123456 B, qid: SELECTExecContext_OK_QID
query cost: 0.0 USD, scanned data: 0 B, qid: SELECTExecContext_OK_QID
query cost: 0.0 USD, scanned data: 0 B, qid: 00000000-0000-0000-0000-000000000000
query cost: 0.00004768371582031250 USD, scanned data: 123 B, qid: SELECTExecContext_OK_QID
query cost: 0.0 USD, scanned data: 0 B, qid: 00000000-0000-0000-0000-000000000000
query cost: 0.00004768371582031250 USD, scanned data: 123 B, qid: SELECTQueryContext_CANCEL_OK_QID
query cost: 0.00004768371582031250 USD, scanned data: 123 B, qid: SELECTQueryContext_AWS_CANCEL_QID
PASS
ok  	github.com/uber/athenadriver/go	33.631s
```