### PR TITLE
Return aws error early if not: workgroup not found

### DIFF
--- a/go/connection.go
+++ b/go/connection.go
@@ -342,6 +342,9 @@ func (c *Connection) QueryContext(ctx context.Context, query string, namedArgs [
 		if err != nil {
 			obs.Scope().Counter(DriverName + ".failure.querycontext.getwg").Inc(1)
 			obs.Log(WarnLevel, "Didn't find workgroup "+wg.Name+" due to: "+err.Error())
+			if reqerr, ok := err.(awserr.RequestFailure); !ok || reqerr.Message() != "WorkGroup is not found." {
+				return nil, err
+			}
 			if c.connector.config.IsWGRemoteCreationAllowed() {
 				err = wg.CreateWGRemotely(c.athenaAPI)
 				if err != nil {


### PR DESCRIPTION
This PR fixes the source of many hours of debugging by not hiding the original error and instead returning it.

Right now, even if your workgroup already exists, this driver will try to create it.
For example, if your aws permissions are not correct, the attempt to get the workgroup will fail.  The driver will then attempt to create the workgroup, and return related to creating the workgroup if that fails too.
Instead, we should only create the workgroup if it does not exist.  Right now, on the v1 aws driver, that is a 400 code error with the text `WorkGroup is not found.`

Reproduce-able setup:
Just make sure the workgroup does already exist, but your aws permissions are incorrect.
```golang
	athenaCfg := athenadrv.NewNoOpsConfig()
	athenaCfg.SetResultPollIntervalSeconds(athenadrv.PoolInterval)
	athenaCfg.SetWGRemoteCreationAllowed(true)
	athenaCfg.SetDB(athenaDatabase)

	err := athenaCfg.SetRegion(awsRegion)
	if err != nil {
		return nil, fmt.Errorf("unable to set athena region: %w", err)
	}

	err = athenaCfg.SetOutputBucket(fmt.Sprintf("s3://%s/%s", athenaResultsBucket, athenaResultsPath))
	if err != nil {
		return nil, fmt.Errorf("unable to set athena output bucket: %w", err)
	}

	err = athenaCfg.SetWorkGroup(athenadrv.NewDefaultWG(athenaWorkgroup, &athenav1.WorkGroupConfiguration{
		EnforceWorkGroupConfiguration:   aws.Bool(false),
		PublishCloudWatchMetricsEnabled: aws.Bool(true),
	}, nil))
	if err != nil {
		return nil, fmt.Errorf("unable to set athena workgroup: %w", err)
	}

	athenaDB, err := sql.Open(athenadrv.DriverName, athenaCfg.Stringify())
```