### PR TITLE
Fix queries without arguments

### DIFF
--- a/go/connection.go
+++ b/go/connection.go
@@ -53,7 +53,7 @@ type Connection struct {
 
 // buildExecutionParams converts Go data types into strings for query arguments in parameterized queries.
 func (c *Connection) buildExecutionParams(args []driver.Value) ([]*string, error) {
-	executionParams := []*string{}
+	var executionParams []*string
 	for _, arg := range args {
 		if arg == nil {
 			val := "NULL"


### PR DESCRIPTION
It seems that https://github.com/uber/athenadriver/pull/63 introduced a bug that broke queries that _aren't_ using arguments. Any queries without arguments now return the following error:

> InvalidParameter: 1 validation error(s) found. - minimum field size of 1, StartQueryExecutionInput.ExecutionParameters. 

The problem is that the `buildExecutionParams` function returns an [empty but non-`nil` slice](https://github.com/uber/athenadriver/pull/63/files#diff-75532d91cea71f85a1c54fe0cf5818a00a4b843ea140eb1a8522410126fee326R56) when no args are provided. That ultimately gets [passed as the `ExecutionParameters` in the call to `StartQueryExecution`](https://github.com/uber/athenadriver/pull/63/files#diff-75532d91cea71f85a1c54fe0cf5818a00a4b843ea140eb1a8522410126fee326R411). That in turn causes a validation error in the underlying Athena library, because it validates that the slice has a length of at least 1 if it's non-nil. See the `min:"1" type:"list"` struct tag on the `ExecutionParameters` field in the [`StartQueryExecutionInput`](https://pkg.go.dev/github.com/aws/aws-sdk-go/service/athena#StartQueryExecutionInput) struct.

This fixes the issue by returning a `nil` slice instead of an empty slice if no args are provided.